### PR TITLE
Remove old search_stories() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,4 @@ Refer to [Clubhouse API Docs](https://clubhouse.io/api/rest/v2/) for more inform
 from clubhouse import ClubhouseClient
 
 clubhouse = ClubhouseClient('your api key')
-
-story = {'name': 'A new story', 'description': 'Do something!'}
-clubhouse.post('stories', json=story)
 ```

--- a/clubhouse/__init__.py
+++ b/clubhouse/__init__.py
@@ -25,14 +25,6 @@ class ClubhouseClient(object):
         self.ignored_status_codes = ignored_status_codes or []
         self.api_key = api_key
 
-    def search_stories(self, **kwargs):
-        result = self._request("get", "search", "stories", json=kwargs)
-        items = result["data"]
-        while "next" in result and result["next"]:
-            result = self._request("get", result["next"])
-            items = [*items, *result["data"]]
-        return items
-
     def get(self, *segments, **kwargs):
         return self._request("get", *segments, **kwargs)
 


### PR DESCRIPTION
The `search_stories()` method has been deprecated. This PR removes the method and updates the Getting Started code example.

![Screen Shot 2020-04-14 at 6 43 38 PM](https://user-images.githubusercontent.com/12974988/79290077-fc79ab80-7e7f-11ea-891a-421d83721152.png)
