### PR TITLE
Add Workflows endpoint

### DIFF
--- a/clubhouse/api.py
+++ b/clubhouse/api.py
@@ -254,3 +254,22 @@ class ClubhouseClient(object):
         '''
         segments = ["milestones", id]
         return self._update_item(data, *segments, **kwargs)
+
+    #############
+    #  Actions  #
+    #############
+
+    def list_workflows(self, **kwargs):
+        '''List all Workflows.
+        https://clubhouse.io/api/rest/v3/#List-Workflows
+
+        Example:
+            from clubhouse import ClubhouseClient
+            conn = ClubhouseClient(API_KEY)
+            conn.list_workflows()
+
+        Returns:
+            A list of dictionaries, where each dictionary is one Workflow.
+        '''
+        segments = ["workflows"]
+        return self._list_items(*segments, **kwargs)

--- a/clubhouse/api.py
+++ b/clubhouse/api.py
@@ -255,9 +255,9 @@ class ClubhouseClient(object):
         segments = ["milestones", id]
         return self._update_item(data, *segments, **kwargs)
 
-    #############
-    #  Actions  #
-    #############
+    ###############
+    #  Workflows  #
+    ###############
 
     def list_workflows(self, **kwargs):
         '''List all Workflows.


### PR DESCRIPTION
**What changes does this PR introduce?**
- Add the `list_workflows()` method to the `ClubhouseClient` class in `api.py`. This is the only endpoint offered by the Clubhouse API for Workflows.

**Tests**
- We'll need to add a unit test for this. I'll create an new issue for this.
